### PR TITLE
Added basic design for how the assets will be contained in the drop down

### DIFF
--- a/Assets/Scenes/Build-Menu.unity
+++ b/Assets/Scenes/Build-Menu.unity
@@ -340,6 +340,7 @@ GameObject:
   - component: {fileID: 203419320}
   - component: {fileID: 203419319}
   - component: {fileID: 203419318}
+  - component: {fileID: 203419321}
   m_Layer: 5
   m_Name: Dropdown
   m_TagString: Untagged
@@ -431,7 +432,19 @@ MonoBehaviour:
       m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_OnValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 203419321}
+        m_TargetAssemblyTypeName: BuildMenu, Assembly-CSharp
+        m_MethodName: dropDownLibrary
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_AlphaFadeSpeed: 0.15
 --- !u!114 &203419319
 MonoBehaviour:
@@ -470,6 +483,155 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 203419316}
+  m_CullTransparentMesh: 1
+--- !u!114 &203419321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203419316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b9f666964a40f074ba40d8e3cc93536c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetPlacement: {fileID: 257516754}
+--- !u!1 &257516752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 257516753}
+  - component: {fileID: 257516755}
+  - component: {fileID: 257516754}
+  m_Layer: 5
+  m_Name: AssetPlaceholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &257516753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257516752}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 976921047}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -284, y: -62}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &257516754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257516752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: asset
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &257516755
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257516752}
   m_CullTransparentMesh: 1
 --- !u!1 &331813622
 GameObject:
@@ -1743,6 +1905,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1403303513}
+  - {fileID: 257516753}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1762,7 +1925,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b9f666964a40f074ba40d8e3cc93536c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sceneState: {fileID: 0}
+  assetPlacement: {fileID: 0}
 --- !u!1 &982643585
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BuildMenu.cs
+++ b/Assets/Scripts/BuildMenu.cs
@@ -1,16 +1,28 @@
 using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
-using UnityEditor.Experimental.Rendering;
+using TMPro;
+
 
 public class BuildMenu : MonoBehaviour
 {
-    [SerializeField] GameObject sceneState; //simply a placeholder until I can find a better/working technique to save an instance of the scene
+    
+    //[SerializeField] GameObject sceneState; //simply a placeholder until I can find a better/working technique to save an instance of the scene
+    [SerializeField] private TMP_Text assetPlacement;
     private bool undoFlag;
     private bool redoFlag;
+    private bool anchor;
+    private bool assetChosen;
     private Stack<string> undoStack = new Stack<string>();
     private Stack<string> redoStack = new Stack<string>();
     private string[] asset = new string[3];//update size based on number of build assets added
+
+    private void Start()
+    {
+        this.asset[0] = "Some asset 1";
+        this.asset[1] = "Some asset 2";
+        this.asset[2] = "Some asset 3";
+    }
 
     public void Exit()//does not save, add functionality to prompt user to save build pregross before exiting
     {
@@ -59,8 +71,28 @@ public class BuildMenu : MonoBehaviour
             //would load the popped item here
         }
     }
+    /*
+     * How to handle drop down menu logic:
+     * Keep track of index position and hardcode each asset to specified index (shouldn't worry about efficiency since there won't be that many assets
+     * Don't know how to implement 'free movement' when pulling and dragging
+     * Can have anchor points set as toggles and user can click desired anchor point after choosing an asset (no need to drag, may be stricter but easier to implement)
+     */
 
-
+    public void dropDownLibrary(int index)//assuming index is automatically provided after method call
+    {
+        if(index == 0)
+        {
+            assetPlacement.text = this.asset[0]; 
+        }
+        else if(index == 1)
+        {
+            assetPlacement.text = this.asset[1];
+        }
+        else if(index == 2)
+        {
+            assetPlacement.text = this.asset[2];
+        }
+    }
 
 
 }


### PR DESCRIPTION
General structure of the build menu has been implemented. Currently there is an array (size of 3) that is intended to hold static assets for the user to choose from in the drop down menu. When the user clicks one of the options in the drop down, there is an asset hardcoded relative to the index position of the option. For now there is a string placeholder for assets in the library, later will implement custom assets (platforms) along with anchor point toggles for assets to be placed on (using the IBeginDragHandler class in unity). 