### PR TITLE
Refines description box and pause/gear menu functionality

### DIFF
--- a/Assets/Scenes/Level-Playing.unity
+++ b/Assets/Scenes/Level-Playing.unity
@@ -216,6 +216,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -475,6 +479,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -584,6 +592,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -646,8 +658,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -50}
-  m_SizeDelta: {x: 290, y: 90}
+  m_AnchoredPosition: {x: 145, y: -60}
+  m_SizeDelta: {x: 290, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &313801734
 CanvasRenderer:
@@ -898,6 +910,142 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &336883329
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 336883330}
+  - component: {fileID: 336883332}
+  - component: {fileID: 336883331}
+  m_Layer: 5
+  m_Name: DescName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &336883330
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336883329}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 525929058}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 145, y: -10}
+  m_SizeDelta: {x: 290, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &336883331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336883329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 5
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &336883332
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336883329}
+  m_CullTransparentMesh: 1
 --- !u!1 &366278843
 GameObject:
   m_ObjectHideFlags: 0
@@ -1106,6 +1254,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -1267,6 +1419,7 @@ GameObject:
   - component: {fileID: 525929060}
   - component: {fileID: 525929059}
   - component: {fileID: 525929061}
+  - component: {fileID: 525929062}
   m_Layer: 5
   m_Name: DescriptionBox
   m_TagString: Untagged
@@ -1286,6 +1439,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 336883330}
   - {fileID: 313801733}
   m_Father: {fileID: 707265708}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1352,6 +1506,107 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &525929062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 525929057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &536735884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 536735885}
+  - component: {fileID: 536735887}
+  - component: {fileID: 536735886}
+  m_Layer: 5
+  m_Name: EquipmentSlotsPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &536735885
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536735884}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 650456544}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -420}
+  m_SizeDelta: {x: 550, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &536735886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536735884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &536735887
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536735884}
+  m_CullTransparentMesh: 1
 --- !u!114 &588625491 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -1599,6 +1854,7 @@ GameObject:
   - component: {fileID: 650456544}
   - component: {fileID: 650456546}
   - component: {fileID: 650456545}
+  - component: {fileID: 650456547}
   m_Layer: 5
   m_Name: GearEquip
   m_TagString: Untagged
@@ -1617,7 +1873,9 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1806055688}
+  - {fileID: 536735885}
   m_Father: {fileID: 707265708}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -1638,7 +1896,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.11764706}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.19607843}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1663,6 +1921,32 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 650456543}
   m_CullTransparentMesh: 1
+--- !u!114 &650456547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 650456543}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 25
+    m_Right: 25
+    m_Top: 25
+    m_Bottom: 25
+  m_ChildAlignment: 1
+  m_Spacing: 25
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &689022665
 GameObject:
   m_ObjectHideFlags: 0
@@ -1808,7 +2092,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.11764706}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.27450982}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1952,6 +2236,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -2060,6 +2348,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -2305,7 +2597,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1730705289}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 2093264212}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2324,7 +2616,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19d2340a58db69240bce6edfa49d7f57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pauseMenu: {fileID: 1730705288}
+  menuManager: {fileID: 2093264213}
 --- !u!224 &989642418 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -2469,6 +2761,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -2677,6 +2973,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -2801,7 +3101,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 707265708}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 2093264212}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2820,7 +3120,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6a792402f80c0ff44ad1875fa06efcd3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GearMenu: {fileID: 707265704}
+  menuManager: {fileID: 2093264213}
   itemSlot:
   - {fileID: 1672201118}
   - {fileID: 373277974}
@@ -2971,6 +3271,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -3080,6 +3384,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -3188,6 +3496,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -3313,6 +3625,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -3471,6 +3787,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -3579,6 +3899,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -3704,6 +4028,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -3969,6 +4297,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -4251,6 +4583,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1782028445}
   m_CullTransparentMesh: 1
+--- !u!1 &1806055687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1806055688}
+  - component: {fileID: 1806055690}
+  - component: {fileID: 1806055689}
+  m_Layer: 5
+  m_Name: EquipmentTitlePanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1806055688
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1806055687}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2113725146}
+  m_Father: {fileID: 650456544}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -55}
+  m_SizeDelta: {x: 550, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1806055689
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1806055687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.39215687}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1806055690
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1806055687}
+  m_CullTransparentMesh: 1
 --- !u!224 &1807831452 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -4473,6 +4881,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -4581,6 +4993,10 @@ PrefabInstance:
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
@@ -4824,6 +5240,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -4836,6 +5256,190 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1 &2093264211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2093264212}
+  - component: {fileID: 2093264213}
+  m_Layer: 0
+  m_Name: MenuManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2093264212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2093264211}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1096.9761, y: 583.6653, z: 6.073133}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 982643589}
+  - {fileID: 1329202080}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2093264213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2093264211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfbc0165fcee1574f911daf484fb13f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pauseMenu: {fileID: 1730705288}
+  gearMenu: {fileID: 707265704}
+--- !u!1 &2113725145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2113725146}
+  - component: {fileID: 2113725148}
+  - component: {fileID: 2113725147}
+  m_Layer: 5
+  m_Name: EquipmentTitleText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2113725146
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113725145}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1806055688}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2113725147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113725145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Equipment
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2113725148
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113725145}
+  m_CullTransparentMesh: 1
 --- !u!1001 &357827128721462464
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4933,6 +5537,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 525929057}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: itemDescriptionName
+      value: 
+      objectReference: {fileID: 336883331}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: itemDescriptionText
       value: 
       objectReference: {fileID: 313801735}
@@ -4955,6 +5563,5 @@ SceneRoots:
   - {fileID: 1171240259}
   - {fileID: 331813625}
   - {fileID: 139002012}
-  - {fileID: 982643589}
-  - {fileID: 1329202080}
   - {fileID: 366278846}
+  - {fileID: 2093264212}

--- a/Assets/Scripts/GearManager.cs
+++ b/Assets/Scripts/GearManager.cs
@@ -2,31 +2,22 @@ using UnityEngine;
 
 public class GearManager : MonoBehaviour
 {
-    public GameObject GearMenu;
-    private bool isOpen;
+    [SerializeField] MenuManager menuManager;
     public ItemSlot[] itemSlot;
 
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.I) &&  isOpen)
+        if (Input.GetKeyDown(KeyCode.I))
         {
-            Time.timeScale = 1;
-            GearMenu.SetActive(false);
-            isOpen = false;
+            menuManager.ToggleGearMenu();
             DeselectAllSlots();
-        }
-        else if (Input.GetKeyDown(KeyCode.I) && !isOpen)
-        {
-            Time.timeScale = 0;
-            GearMenu.SetActive(true);
-            isOpen = true;
         }
     }
 
     public void AddItem(string itemName, Sprite itemSprite, string itemDescription)
     {
-        Debug.Log("itemName = " + itemName + "itemSprite = " + itemSprite);
+        //Debug.Log("itemName = " + itemName + "itemSprite = " + itemSprite);
         for (int i = 0; i < itemSlot.Length; i++)
         {
             if (itemSlot[i].isFull == false)

--- a/Assets/Scripts/ItemSlot.cs
+++ b/Assets/Scripts/ItemSlot.cs
@@ -14,7 +14,7 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
     public bool isFull;
     [SerializeField] private Image itemImage;
     public TMP_Text itemDescriptionText;
-    //public TMP_Text itemDescriptionName;
+    public TMP_Text itemDescriptionName;
 
     public GameObject selectedShader;
     public bool isSelected;
@@ -62,9 +62,12 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
 
         descriptionBox.GetComponent<RectTransform>().position = new Vector3((GetComponent<RectTransform>().position.x + 75), (GetComponent<RectTransform>().position.y - 125), (GetComponent<RectTransform>().position.z));
 
-        descriptionBox.SetActive(true);
-        //itemDescriptionName.text = itemName;
-        itemDescriptionText.text = itemDescription;
+        if (isFull)
+        {
+            descriptionBox.SetActive(true);
+            itemDescriptionName.text = itemName;
+            itemDescriptionText.text = itemDescription;
+        }
     }
 
     //Deselects an itemslot in the gear menu

--- a/Assets/Scripts/MenuManager.cs
+++ b/Assets/Scripts/MenuManager.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class MenuManager : MonoBehaviour
+{
+    [SerializeField] GameObject pauseMenu;
+    private bool isPauseMenuOpen = false;
+    [SerializeField] GameObject gearMenu;
+    private bool isGearMenuOpen = false;
+
+    private void ToggleTime(bool isPaused)
+    {
+        Time.timeScale = isPaused ? 0.0f : 1.0f;
+    }
+
+    public void TogglePauseMenu()
+    {
+        //Closes GearMenu if it is open
+        if (isGearMenuOpen) { ToggleGearMenu(); }
+
+        isPauseMenuOpen = !isPauseMenuOpen;
+        pauseMenu.SetActive(isPauseMenuOpen);
+        ToggleTime(isPauseMenuOpen);
+    }
+
+    public void ToggleGearMenu()
+    {
+        //Does not allow GearMenu to open when PauseMenu is open
+        if (isPauseMenuOpen) { return; }
+
+        isGearMenuOpen = !isGearMenuOpen;
+        gearMenu.SetActive(isGearMenuOpen);
+        ToggleTime(isGearMenuOpen);
+    }
+}

--- a/Assets/Scripts/MenuManager.cs.meta
+++ b/Assets/Scripts/MenuManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dfbc0165fcee1574f911daf484fb13f0

--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -3,8 +3,7 @@ using UnityEngine.SceneManagement;
 
 public class PauseMenu : MonoBehaviour
 {
-    [SerializeField] GameObject pauseMenu;
-    private bool isPaused = false;
+    [SerializeField] MenuManager menuManager;
 
     public void MainMenu()
     {
@@ -17,12 +16,7 @@ public class PauseMenu : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.Escape))
         {
-            isPaused = !isPaused;
-            pauseMenu.SetActive(isPaused);
-            if (isPaused)
-                Time.timeScale = 0;
-            else
-                Time.timeScale = 1;
+            menuManager.TogglePauseMenu();
         }
     }
 }


### PR DESCRIPTION
Description boxs now only appear in selected slots that have an item in them.  Description boxes now show the name of the item in addition to the item's description.  Added MenuManager panel and accompanying script which fixes bug that allowed users to open both the pauseMenu and GearMenu where closing one would unpause the game.  Setup for Equipment tab which will begin development next commit.