### PR TITLE
Add equipping and unequipping items from inventory

### DIFF
--- a/Assets/EquipSlot.prefab
+++ b/Assets/EquipSlot.prefab
@@ -1,0 +1,366 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1030433438050590105
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 714067496356506116}
+  - component: {fileID: 2445811037983099356}
+  - component: {fileID: 8364471075793108460}
+  m_Layer: 5
+  m_Name: SelectedPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &714067496356506116
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030433438050590105}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6884764722670552099}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 9.999981, y: 9.999996}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2445811037983099356
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030433438050590105}
+  m_CullTransparentMesh: 1
+--- !u!114 &8364471075793108460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030433438050590105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5608834364661489132
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1581822206977806245}
+  - component: {fileID: 7042062036343228026}
+  - component: {fileID: 1832932419034060669}
+  m_Layer: 5
+  m_Name: ItemImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1581822206977806245
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5608834364661489132}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6884764722670552099}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7042062036343228026
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5608834364661489132}
+  m_CullTransparentMesh: 1
+--- !u!114 &1832932419034060669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5608834364661489132}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.028301895, g: 0.025765404, b: 0.025765404, a: 0.972549}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5836667891652344425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6884764722670552099}
+  - component: {fileID: 1850552331499508772}
+  - component: {fileID: 8542211756071878907}
+  m_Layer: 5
+  m_Name: EquipSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6884764722670552099
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5836667891652344425}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 714067496356506116}
+  - {fileID: 1581822206977806245}
+  - {fileID: 2851965615081272685}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1850552331499508772
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5836667891652344425}
+  m_CullTransparentMesh: 1
+--- !u!114 &8542211756071878907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5836667891652344425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6281060595392262300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2851965615081272685}
+  - component: {fileID: 6295214854176131369}
+  - component: {fileID: 7620288030067180702}
+  m_Layer: 5
+  m_Name: EquipSlotName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2851965615081272685
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6281060595392262300}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6884764722670552099}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6295214854176131369
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6281060595392262300}
+  m_CullTransparentMesh: 1
+--- !u!114 &7620288030067180702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6281060595392262300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Head
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/EquipSlot.prefab.meta
+++ b/Assets/EquipSlot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4287d31276bce124692f878e4d78d097
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Level-Playing.unity
+++ b/Assets/Scenes/Level-Playing.unity
@@ -221,6 +221,83 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1 &39899052
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 39899053}
+  - component: {fileID: 39899055}
+  - component: {fileID: 39899054}
+  m_Layer: 5
+  m_Name: EquipDesc
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &39899053
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39899052}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 929915176}
+  - {fileID: 1362598772}
+  m_Father: {fileID: 1768816469}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 260, y: 0}
+  m_SizeDelta: {x: 300, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &39899054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39899052}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15792987, g: 0.3679245, b: 0.35479984, a: 0.9411765}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &39899055
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39899052}
+  m_CullTransparentMesh: 1
 --- !u!1001 &61704775
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -314,6 +391,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -334,6 +423,83 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1 &94990202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 94990203}
+  - component: {fileID: 94990205}
+  - component: {fileID: 94990204}
+  m_Layer: 5
+  m_Name: EquipDesc
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &94990203
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94990202}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 635828616}
+  - {fileID: 759964455}
+  m_Father: {fileID: 536778191}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 260, y: 0}
+  m_SizeDelta: {x: 300, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &94990204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94990202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15792987, g: 0.3679245, b: 0.35479984, a: 0.9411765}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &94990205
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94990202}
+  m_CullTransparentMesh: 1
 --- !u!1 &139002009
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,6 +650,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &171953052 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1832932419034060669, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 1225418445}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &201037433
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -576,6 +753,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -689,6 +878,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -846,6 +1047,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 274430321}
   m_CullTransparentMesh: 1
+--- !u!1 &278521886 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1030433438050590105, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 1225418445}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &302720646 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -1360,6 +1566,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 343007109}
   m_CullTransparentMesh: 1
+--- !u!1 &361242548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 361242549}
+  - component: {fileID: 361242551}
+  - component: {fileID: 361242550}
+  m_Layer: 5
+  m_Name: EquipDescName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &361242549
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 361242548}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 531363140}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 290, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &361242550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 361242548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &361242551
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 361242548}
+  m_CullTransparentMesh: 1
 --- !u!1 &366278843
 GameObject:
   m_ObjectHideFlags: 0
@@ -1394,6 +1736,7 @@ MonoBehaviour:
   sprite: {fileID: 7392569859222569844, guid: 7f010d400610fe84eacf4e6f9fafaf47, type: 3}
   itemDescription: Test Item, Increases max Player jumps by 1.
   gearManager: {fileID: 0}
+  gearType: 2
   tipBox: {fileID: 343007109}
 --- !u!61 &366278845
 BoxCollider2D:
@@ -1473,6 +1816,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &426725096 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1030433438050590105, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 621514945}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &513939097
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1565,6 +1913,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -1848,6 +2208,83 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &531363139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 531363140}
+  - component: {fileID: 531363142}
+  - component: {fileID: 531363141}
+  m_Layer: 5
+  m_Name: EquipDesc
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &531363140
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531363139}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 361242549}
+  - {fileID: 1494303396}
+  m_Father: {fileID: 1477500179}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 260, y: 0}
+  m_SizeDelta: {x: 300, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &531363141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531363139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15792987, g: 0.3679245, b: 0.35479984, a: 0.9411765}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &531363142
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531363139}
+  m_CullTransparentMesh: 1
 --- !u!1 &536735884
 GameObject:
   m_ObjectHideFlags: 0
@@ -1859,6 +2296,7 @@ GameObject:
   - component: {fileID: 536735885}
   - component: {fileID: 536735887}
   - component: {fileID: 536735886}
+  - component: {fileID: 536735888}
   m_Layer: 5
   m_Name: EquipmentSlotsPanel
   m_TagString: Untagged
@@ -1877,7 +2315,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1477500179}
+  - {fileID: 536778191}
+  - {fileID: 1768816469}
   m_Father: {fileID: 650456544}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -1923,6 +2364,62 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 536735884}
   m_CullTransparentMesh: 1
+--- !u!114 &536735888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536735884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 30
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &536778190 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 621514945}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &536778191 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 621514945}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &536778194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536778190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e54c804b143e154eac76605ab302f54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slotImage: {fileID: 1181320997}
+  slotName: {fileID: 847182319}
+  gearType: 2
+  selectedShader: {fileID: 426725096}
+  isSelected: 0
+  descBox: {fileID: 94990202}
+  itemDescriptionText: {fileID: 759964456}
+  itemDescriptionName: {fileID: 635828617}
 --- !u!114 &588625491 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -2159,6 +2656,257 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &621514945
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 536735885}
+    m_Modifications:
+    - target: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Name
+      value: WeaponSlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 105
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_text
+      value: Weapon
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSize
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 30
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 94990203}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 536778194}
+  m_SourcePrefab: {fileID: 100100000, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+--- !u!1 &635828615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 635828616}
+  - component: {fileID: 635828618}
+  - component: {fileID: 635828617}
+  m_Layer: 5
+  m_Name: EquipDescName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &635828616
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635828615}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 94990203}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 290, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &635828617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635828615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &635828618
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635828615}
+  m_CullTransparentMesh: 1
 --- !u!1 &650456543
 GameObject:
   m_ObjectHideFlags: 0
@@ -2548,6 +3296,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -2568,6 +3328,142 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1 &759964454
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 759964455}
+  - component: {fileID: 759964457}
+  - component: {fileID: 759964456}
+  m_Layer: 5
+  m_Name: EquipDescText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &759964455
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759964454}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 94990203}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 290, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &759964456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759964454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT BUT WAYYYYY MORE JKSRGLUSNUGN
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &759964457
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759964454}
+  m_CullTransparentMesh: 1
 --- !u!1001 &806180959
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2660,6 +3556,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -2801,6 +3709,22 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846365286}
   m_CullTransparentMesh: 1
+--- !u!114 &847182319 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 621514945}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &858488412 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1030433438050590105, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 7482497619726229866}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &870445395 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -2817,6 +3741,142 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &929915173
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 929915176}
+  - component: {fileID: 929915175}
+  - component: {fileID: 929915174}
+  m_Layer: 5
+  m_Name: EquipDescName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &929915174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929915173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &929915175
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929915173}
+  m_CullTransparentMesh: 1
+--- !u!224 &929915176
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929915173}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 39899053}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 290, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &982643585
 GameObject:
   m_ObjectHideFlags: 0
@@ -3074,6 +4134,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -3176,6 +4248,17 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1835789645}
   m_SourcePrefab: {fileID: -8435245712485981826, guid: 0c621ce7e0364af4ba7ff6f9497e1c53, type: 3}
+--- !u!114 &1181320997 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1832932419034060669, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 621514945}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &1182938379 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -3285,6 +4368,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -3305,6 +4400,121 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1001 &1225418445
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 536735885}
+    m_Modifications:
+    - target: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Name
+      value: BodySlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 105
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -500
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_text
+      value: Body
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSize
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 30
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 39899053}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1768816472}
+  m_SourcePrefab: {fileID: 100100000, guid: 4287d31276bce124692f878e4d78d097, type: 3}
 --- !u!224 &1297639302 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -3458,6 +4668,157 @@ MonoBehaviour:
   - {fileID: 1807831455}
   - {fileID: 1517232939}
   - {fileID: 588625491}
+  equipSlot:
+  - {fileID: 1477500182}
+  - {fileID: 536778194}
+  - {fileID: 1768816472}
+--- !u!114 &1355834018 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1832932419034060669, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 7482497619726229866}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1362598771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1362598772}
+  - component: {fileID: 1362598773}
+  - component: {fileID: 1362598774}
+  m_Layer: 5
+  m_Name: EquipDescText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1362598772
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362598771}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 39899053}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 290, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1362598773
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362598771}
+  m_CullTransparentMesh: 1
+--- !u!114 &1362598774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362598771}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT BUT WAYYYYY MORE JKSRGLUSNUGN
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!224 &1378754116 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -3583,6 +4944,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -3603,6 +4976,36 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1 &1477500178 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 7482497619726229866}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1477500179 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 7482497619726229866}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1477500182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1477500178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e54c804b143e154eac76605ab302f54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slotImage: {fileID: 1355834018}
+  slotName: {fileID: 1519035983}
+  gearType: 1
+  selectedShader: {fileID: 858488412}
+  isSelected: 0
+  descBox: {fileID: 531363139}
+  itemDescriptionText: {fileID: 1494303397}
+  itemDescriptionName: {fileID: 361242550}
 --- !u!1001 &1477712740
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3696,6 +5099,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -3716,6 +5131,142 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1 &1494303395
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1494303396}
+  - component: {fileID: 1494303398}
+  - component: {fileID: 1494303397}
+  m_Layer: 5
+  m_Name: EquipDescText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1494303396
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494303395}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 531363140}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 290, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1494303397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494303395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST TEXT BUT WAYYYYY MORE JKSRGLUSNUGN
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1494303398
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494303395}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1496901069
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3809,6 +5360,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -3843,6 +5406,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1519035983 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 7482497619726229866}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1554408863
@@ -3937,6 +5511,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -4131,6 +5717,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -4243,6 +5841,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -4372,6 +5982,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -4642,6 +6264,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -4798,6 +6432,36 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1765245519}
   m_CullTransparentMesh: 1
+--- !u!1 &1768816468 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 1225418445}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1768816469 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 1225418445}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1768816472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1768816468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e54c804b143e154eac76605ab302f54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slotImage: {fileID: 171953052}
+  slotName: {fileID: 1821834201}
+  gearType: 3
+  selectedShader: {fileID: 278521886}
+  isSelected: 0
+  descBox: {fileID: 39899052}
+  itemDescriptionText: {fileID: 1362598774}
+  itemDescriptionName: {fileID: 929915174}
 --- !u!1 &1782028445
 GameObject:
   m_ObjectHideFlags: 0
@@ -5023,6 +6687,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1821834201 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+  m_PrefabInstance: {fileID: 1225418445}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1835789639 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2253911629886400664, guid: 0c621ce7e0364af4ba7ff6f9497e1c53, type: 3}
@@ -5113,9 +6788,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23e787bc9e6a1d542900a5c88ba4e1ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 5
-  jumpForce: 7
-  maxJumps: 2
 --- !u!224 &1850661024 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3179199221722828622, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
@@ -5224,6 +6896,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -5337,6 +7021,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -5583,6 +7279,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
@@ -5881,6 +7589,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: bodySlot
+      value: 
+      objectReference: {fileID: 1768816472}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: headSlot
+      value: 
+      objectReference: {fileID: 1477500182}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+      propertyPath: weaponSlot
+      value: 
+      objectReference: {fileID: 536778194}
+    - target: {fileID: 4248796102370013890, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
       propertyPath: descriptionBox
       value: 
       objectReference: {fileID: 525929057}
@@ -5901,6 +7621,117 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 663cd52a6f744f043861cd72befa901e, type: 3}
+--- !u!1001 &7482497619726229866
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 536735885}
+    m_Modifications:
+    - target: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Name
+      value: HeadSlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 105
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSize
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620288030067180702, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 30
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 6884764722670552099, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 531363140}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5836667891652344425, guid: 4287d31276bce124692f878e4d78d097, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1477500182}
+  m_SourcePrefab: {fileID: 100100000, guid: 4287d31276bce124692f878e4d78d097, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EquipSlot.cs
+++ b/Assets/Scripts/EquipSlot.cs
@@ -1,0 +1,109 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.EventSystems;
+
+public class EquipSlot : MonoBehaviour, IPointerClickHandler
+{
+    [SerializeField] private Image slotImage;
+    [SerializeField] private TMP_Text slotName;
+    [SerializeField] private GearManager.GearType gearType = new GearManager.GearType();
+
+    private Sprite itemSprite;
+    private string itemName;
+    private string itemDescription;
+
+    private bool isFull = false;
+
+
+    [SerializeField] public GameObject selectedShader;
+    public bool isSelected;
+
+    [SerializeField] public GameObject descBox;
+    public TMP_Text itemDescriptionText;
+    public TMP_Text itemDescriptionName;
+
+    private GearManager gearManager;
+    private void Start()
+    {
+        gearManager = GameObject.Find("GearCanvas").GetComponent<GearManager>();
+    }
+
+    public void EquipGear(string itemName, Sprite itemSprite, string itemDescription)
+    {
+        if (isFull)
+        {
+            UnEquipGear();
+        }
+
+        this.itemSprite = itemSprite;
+        slotImage.sprite = itemSprite;
+        slotName.enabled = false;
+
+        this.itemName = itemName;
+        this.itemDescription = itemDescription;
+
+        //This is where we actually update the player's stats
+        /*
+        if (itemName == "Blaster")
+        {
+            PlayerMovement.maxJumps += 1;
+        }
+        */
+
+        isFull = true;
+        descBox.SetActive(true);
+        itemDescriptionName.text = itemName;
+        itemDescriptionText.text = itemDescription;
+    }
+
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (eventData.button == PointerEventData.InputButton.Left)
+        {
+            OnLeftClick();
+        }
+        if (eventData.button == PointerEventData.InputButton.Right)
+        {
+            OnRightClick();
+        }
+    }
+
+    //Selects an equipment slot
+    private void OnLeftClick()
+    {
+        if (isSelected && isFull)
+        {
+            UnEquipGear();
+        }
+        else
+        {
+            gearManager.DeselectAllSlots();
+            selectedShader.SetActive(true);
+            isSelected = true;
+        }
+    }
+
+    //Deselects an equipment slot
+    private void OnRightClick()
+    {
+        selectedShader.SetActive(false);
+        isSelected = false;
+    }
+
+    public void UnEquipGear()
+    {
+        selectedShader.SetActive(false);
+        isSelected = false;
+        descBox.SetActive(false);
+
+        gearManager.AddItem(itemName, itemSprite, itemDescription, gearType);
+
+
+        this.itemSprite = null;
+        slotImage.sprite = null;
+        slotName.enabled = true;
+
+        isFull = false;
+    }
+}

--- a/Assets/Scripts/EquipSlot.cs.meta
+++ b/Assets/Scripts/EquipSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e54c804b143e154eac76605ab302f54

--- a/Assets/Scripts/GearManager.cs
+++ b/Assets/Scripts/GearManager.cs
@@ -4,6 +4,7 @@ public class GearManager : MonoBehaviour
 {
     [SerializeField] public MenuManager menuManager;
     public ItemSlot[] itemSlot;
+    public EquipSlot[] equipSlot;
 
     // Update is called once per frame
     void Update()
@@ -15,14 +16,14 @@ public class GearManager : MonoBehaviour
         }
     }
 
-    public void AddItem(string itemName, Sprite itemSprite, string itemDescription)
+    public void AddItem(string itemName, Sprite itemSprite, string itemDescription, GearType gearType)
     {
         //Debug.Log("itemName = " + itemName + "itemSprite = " + itemSprite);
         for (int i = 0; i < itemSlot.Length; i++)
         {
             if (itemSlot[i].isFull == false)
             {
-                itemSlot[i].AddItem(itemName, itemSprite, itemDescription);
+                itemSlot[i].AddItem(itemName, itemSprite, itemDescription, gearType);
                 return;
             }
         }
@@ -37,4 +38,12 @@ public class GearManager : MonoBehaviour
             itemSlot[i].isSelected = false;
         }
     }
+
+    public enum GearType
+    {
+        none,
+        head,
+        weapon,
+        body,
+    };
 }

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -8,6 +8,8 @@ public class Item : MonoBehaviour
 
     public GearManager gearManager;
 
+    public GearManager.GearType gearType;
+
     private bool isPlayerColliding = false;
 
     public GameObject tipBox;
@@ -22,7 +24,7 @@ public class Item : MonoBehaviour
     {
         if (isPlayerColliding && Input.GetKeyDown(KeyCode.F))
         {
-            gearManager.AddItem(itemName, sprite, itemDescription);
+            gearManager.AddItem(itemName, sprite, itemDescription, gearType);
             tipBox.SetActive(false);
             Destroy(gameObject);
         }
@@ -55,7 +57,7 @@ public class Item : MonoBehaviour
     {
         if (gearManager != null)
         {
-            gearManager.AddItem(itemName, sprite, itemDescription);
+            gearManager.AddItem(itemName, sprite, itemDescription, gearType);
             DestroyImmediate(gameObject);
         }
     }

--- a/Assets/Scripts/ItemSlot.cs
+++ b/Assets/Scripts/ItemSlot.cs
@@ -11,8 +11,9 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
     public string itemName;
     public Sprite itemSprite;
     public string itemDescription;
-    public bool isFull;
+    public bool isFull = false;
     [SerializeField] public Image itemImage;
+    public GearManager.GearType gearType;
     public TMP_Text itemDescriptionText;
     public TMP_Text itemDescriptionName;
 
@@ -23,17 +24,20 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
 
     private GearManager gearManager;
 
+    [SerializeField] public EquipSlot headSlot, weaponSlot, bodySlot;
+
     private void Start()
     {
         gearManager = GameObject.Find("GearCanvas").GetComponent<GearManager>();
     }
 
 
-    public void AddItem(string itemName, Sprite itemSprite, string itemDescription)
+    public void AddItem(string itemName, Sprite itemSprite, string itemDescription, GearManager.GearType gearType)
     {
         this.itemName = itemName;
         this.itemSprite = itemSprite;
         this.itemDescription = itemDescription;
+        this.gearType = gearType;
         isFull = true;
 
         itemImage.sprite = itemSprite;
@@ -56,17 +60,24 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
     //Selects an itemslot in the gear menu
     private void OnLeftClick()
     {
-        gearManager.DeselectAllSlots();
-        selectedShader.SetActive(true);
-        isSelected = true;
-
-        descriptionBox.GetComponent<RectTransform>().position = new Vector3((GetComponent<RectTransform>().position.x + 75), (GetComponent<RectTransform>().position.y - 125), (GetComponent<RectTransform>().position.z));
-
-        if (isFull)
+        if (isSelected && isFull)
         {
-            descriptionBox.SetActive(true);
-            itemDescriptionName.text = itemName;
-            itemDescriptionText.text = itemDescription;
+            EquipGear();
+        }
+        else
+        {
+            gearManager.DeselectAllSlots();
+            selectedShader.SetActive(true);
+            isSelected = true;
+
+            descriptionBox.GetComponent<RectTransform>().position = new Vector3((GetComponent<RectTransform>().position.x + 75), (GetComponent<RectTransform>().position.y - 125), (GetComponent<RectTransform>().position.z));
+
+            if (isFull)
+            {
+                descriptionBox.SetActive(true);
+                itemDescriptionName.text = itemName;
+                itemDescriptionText.text = itemDescription;
+            }
         }
     }
 
@@ -77,5 +88,30 @@ public class ItemSlot : MonoBehaviour, IPointerClickHandler
         isSelected = false;
 
         descriptionBox.SetActive(false);
+    }
+
+    private void EquipGear()
+    {
+        if (gearType == GearManager.GearType.head)
+        {
+            headSlot.EquipGear(itemName, itemSprite, itemDescription);
+        }
+        if (gearType == GearManager.GearType.weapon)
+        {
+            weaponSlot.EquipGear(itemName, itemSprite, itemDescription);
+        }
+        if (gearType == GearManager.GearType.body)
+        {
+            bodySlot.EquipGear(itemName, itemSprite, itemDescription);
+        }
+
+        EmptySlot();
+    }
+
+    private void EmptySlot()
+    {
+        gearManager.DeselectAllSlots();
+        itemImage.sprite = null;
+        isFull = false;
     }
 }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -3,11 +3,11 @@ using UnityEngine;
 public class PlayerMovement : MonoBehaviour
 {
     // Public variables for movement speed, jump force, and max jumps, which is adjustable in Unity.
-    public float speed = 5f;
+    public static float speed = 5f;
 
-    public float jumpForce = 7f;
+    public static float jumpForce = 7f;
     
-    public int maxJumps = 2;
+    public static int maxJumps = 2;
 
     // Reference to the Rigidbody2D component for the physics interactions.
     private Rigidbody2D rb;

--- a/Assets/Sprites/anchorslot.png.meta
+++ b/Assets/Sprites/anchorslot.png.meta
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      anchorslot_0: 8358776300379455534
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Sprites/platform.png.meta
+++ b/Assets/Sprites/platform.png.meta
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      platform_0: -5113850848988359095
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Sprites/platformSprite.png.meta
+++ b/Assets/Sprites/platformSprite.png.meta
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      platformSprite_0: 2230925900812979055
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Sprites/slot 1.png.meta
+++ b/Assets/Sprites/slot 1.png.meta
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      slot 1_0: 1534783662646043209
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Sprites/slot.png.meta
+++ b/Assets/Sprites/slot.png.meta
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      slot_0: -8358113870863188520
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Tests/EditorTests/ItemSlotTests.cs
+++ b/Assets/Tests/EditorTests/ItemSlotTests.cs
@@ -55,7 +55,7 @@ public class ItemSlotTests
         Sprite testItemSprite = Sprite.Create(Texture2D.blackTexture, new Rect(0, 0, 3, 3), Vector2.zero);
         string testItemDescription = "Test Description, very descriptive and informative";
 
-        slot.AddItem(testItemName, testItemSprite, testItemDescription);
+        slot.AddItem(testItemName, testItemSprite, testItemDescription, GearManager.GearType.none);
 
         Assert.AreEqual(testItemName, slot.itemName, "Item name should be correctly assigned");
         Assert.AreEqual(testItemSprite, slot.itemSprite, "Item sprite should be correctly assigned");


### PR DESCRIPTION
Items in inventory can now be equipped to one of the three equipment slots, this can be done by double left-clicking the item, this is also how unequiping items works.  
Actual functionality of items is right around the corner, just need to discuss a few things with Ian before I can edit stats though an example is given in EquipSlot.  Made stat fields in PlayerMovement static to allow for editing later.