### PR TITLE
add item functionality logic and compatibility with  player attributes

### DIFF
--- a/Assets/EquipmentScriptables.meta
+++ b/Assets/EquipmentScriptables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d04fd911f701ff8438af4e33bf8006ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EquipmentScriptables/Blaster.asset
+++ b/Assets/EquipmentScriptables/Blaster.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30792922ca8a2b24b9c3d8cbbaf5f45a, type: 3}
+  m_Name: Blaster
+  m_EditorClassIdentifier: 
+  itemName: Blaster
+  playerAtkDamage: 0
+  playerMaxHealth: 0
+  playerMaxJumps: 1
+  playerAtkRange: 0
+  playerSpeed: 0
+  playerJumpForce: 0

--- a/Assets/EquipmentScriptables/Blaster.asset.meta
+++ b/Assets/EquipmentScriptables/Blaster.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 402aa65452c2b3d42baa4eb9c1405520
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Level-Playing.unity
+++ b/Assets/Scenes/Level-Playing.unity
@@ -4041,6 +4041,56 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1677d34e6b5f0244b603d595a34c165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1137244832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1137244834}
+  - component: {fileID: 1137244833}
+  m_Layer: 0
+  m_Name: StatManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1137244833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137244832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70e7cb7584e201342a10c32090298fdd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerAtkDamage: 20
+  playerAtkRange: 5
+  playerMaxHealth: 100
+  playerSpeed: 5
+  playerJumpForce: 7
+  playerMaxJumps: 2
+--- !u!4 &1137244834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137244832}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 946.15906, y: 619.9659, z: -5.3246765}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1145013127
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4544,6 +4594,7 @@ GameObject:
   - component: {fileID: 1329202078}
   - component: {fileID: 1329202077}
   - component: {fileID: 1329202081}
+  - component: {fileID: 1329202082}
   m_Layer: 5
   m_Name: GearCanvas
   m_TagString: Untagged
@@ -4672,6 +4723,20 @@ MonoBehaviour:
   - {fileID: 1477500182}
   - {fileID: 536778194}
   - {fileID: 1768816472}
+--- !u!114 &1329202082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1329202076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a51194958e2b5646af56a15acdd8c82, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  equipmentscriptable:
+  - {fileID: 11400000, guid: 402aa65452c2b3d42baa4eb9c1405520, type: 2}
 --- !u!114 &1355834018 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1832932419034060669, guid: 4287d31276bce124692f878e4d78d097, type: 3}
@@ -7745,3 +7810,4 @@ SceneRoots:
   - {fileID: 366278846}
   - {fileID: 2093264212}
   - {fileID: 1631703037}
+  - {fileID: 1137244834}

--- a/Assets/Scripts/EquipSlot.cs
+++ b/Assets/Scripts/EquipSlot.cs
@@ -24,9 +24,13 @@ public class EquipSlot : MonoBehaviour, IPointerClickHandler
     public TMP_Text itemDescriptionName;
 
     private GearManager gearManager;
+    private EquipmentScriptablesLibrary equipmentLibrary;
+    private PlayerMovement playerMovement;
     private void Start()
     {
         gearManager = GameObject.Find("GearCanvas").GetComponent<GearManager>();
+        equipmentLibrary = GameObject.Find("GearCanvas").GetComponent<EquipmentScriptablesLibrary>();
+        playerMovement = GameObject.Find("Player").GetComponent<PlayerMovement>();
     }
 
     public void EquipGear(string itemName, Sprite itemSprite, string itemDescription)
@@ -44,12 +48,21 @@ public class EquipSlot : MonoBehaviour, IPointerClickHandler
         this.itemDescription = itemDescription;
 
         //This is where we actually update the player's stats
+        for (int i = 0; i < equipmentLibrary.equipmentscriptable.Length; i++)
+        {
+            if (equipmentLibrary.equipmentscriptable[i].itemName == this.itemName) 
+            {
+                equipmentLibrary.equipmentscriptable[i].EquipItem();
+            }
+        }
         /*
         if (itemName == "Blaster")
         {
             PlayerMovement.maxJumps += 1;
         }
         */
+
+        playerMovement.UpdateJumpCount();
 
         isFull = true;
         descBox.SetActive(true);
@@ -103,6 +116,15 @@ public class EquipSlot : MonoBehaviour, IPointerClickHandler
         this.itemSprite = null;
         slotImage.sprite = null;
         slotName.enabled = true;
+
+        for (int i = 0; i < equipmentLibrary.equipmentscriptable.Length; i++)
+        {
+            if (equipmentLibrary.equipmentscriptable[i].itemName == this.itemName)
+            {
+                equipmentLibrary.equipmentscriptable[i].UnEquipItem();
+            }
+        }
+        playerMovement.UpdateJumpCount();
 
         isFull = false;
     }

--- a/Assets/Scripts/EquipmentScriptable.cs
+++ b/Assets/Scripts/EquipmentScriptable.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "EquipmentScriptable", menuName = "Scriptable Objects/EquipmentScriptable")]
+public class EquipmentScriptable : ScriptableObject
+{
+    public string itemName;
+    public int playerAtkDamage, playerMaxHealth, playerMaxJumps;
+    public float playerAtkRange, playerSpeed, playerJumpForce;
+
+    /* List other player attributes here
+     * MaxAmmo?
+     * AtkSpeed?
+     * 
+     */
+
+    //Updates all player stats when new item is equipped
+    public void EquipItem()
+    {
+        PlayerStats playerstats = GameObject.Find("StatManager").GetComponent<PlayerStats>();
+        playerstats.playerAtkDamage += playerAtkDamage;
+        playerstats.playerMaxHealth += playerMaxHealth;
+        playerstats.playerMaxJumps += playerMaxJumps;
+        playerstats.playerAtkRange += playerAtkRange;
+        playerstats.playerSpeed += playerSpeed;
+        playerstats.playerJumpForce += playerJumpForce;
+    }
+
+    public void UnEquipItem()
+    {
+        PlayerStats playerstats = GameObject.Find("StatManager").GetComponent<PlayerStats>();
+        playerstats.playerAtkDamage -= playerAtkDamage;
+        playerstats.playerMaxHealth -= playerMaxHealth;
+        playerstats.playerMaxJumps -= playerMaxJumps;
+        playerstats.playerAtkRange -= playerAtkRange;
+        playerstats.playerSpeed -= playerSpeed;
+        playerstats.playerJumpForce -= playerJumpForce;
+    }
+
+}

--- a/Assets/Scripts/EquipmentScriptable.cs.meta
+++ b/Assets/Scripts/EquipmentScriptable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30792922ca8a2b24b9c3d8cbbaf5f45a

--- a/Assets/Scripts/EquipmentScriptablesLibrary.cs
+++ b/Assets/Scripts/EquipmentScriptablesLibrary.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class EquipmentScriptablesLibrary : MonoBehaviour
+{
+    public EquipmentScriptable[] equipmentscriptable;
+}

--- a/Assets/Scripts/EquipmentScriptablesLibrary.cs.meta
+++ b/Assets/Scripts/EquipmentScriptablesLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5a51194958e2b5646af56a15acdd8c82

--- a/Assets/Scripts/PlayerCombat.cs
+++ b/Assets/Scripts/PlayerCombat.cs
@@ -3,21 +3,17 @@ using System.Collections;
 
 public class PlayerCombat : MonoBehaviour
 {
+    // Reference Player stats to get changeable attributes
+    private PlayerStats playerStats;
+
     // Reference to the Animator component for handling attack animations.
     public Animator animator;
 
     // Reference to the attack point where the attack will be detected.
     public Transform attackPoint;
 
-    // Radius of the attack hitbox.
-    public float attackRange = 0.5f;
-
     // LayerMask to determine which objects should be detected as enemies.
     public LayerMask enemyLayers;
-
-    // Damage value inflicted on enemies.
-    public int attackDamage = 20;
-    public int maxHealth = 100;
 
     private int currentHealth;
     private bool isDead = false;
@@ -44,7 +40,10 @@ public class PlayerCombat : MonoBehaviour
 
      void Start()
     {
-        currentHealth = maxHealth;
+        // Get the PlayerStats component attached to the same GameObject
+        playerStats = GameObject.Find("StatManager").GetComponent<PlayerStats>();
+
+        currentHealth = playerStats.playerMaxHealth;
         currentAmmo = maxAmmo;
     }
 
@@ -158,7 +157,7 @@ public class PlayerCombat : MonoBehaviour
     {
 
         // Detect all enemies within the attack range.
-        Collider2D[] hitEnemies = Physics2D.OverlapCircleAll(attackPoint.position, attackRange, enemyLayers);
+        Collider2D[] hitEnemies = Physics2D.OverlapCircleAll(attackPoint.position, playerStats.playerAtkRange, enemyLayers);
 
         Debug.Log("Enemies hit: " + hitEnemies.Length);
 
@@ -166,7 +165,7 @@ public class PlayerCombat : MonoBehaviour
         foreach (Collider2D enemy in hitEnemies)
         {
             Debug.Log("Enemy hit: " + enemy.gameObject.name);
-            enemy.GetComponent<Enemy>().TakeDamage(attackDamage); // Calls the TakeDamge method in the Enemy script.
+            enemy.GetComponent<Enemy>().TakeDamage(playerStats.playerAtkDamage); // Calls the TakeDamge method in the Enemy script.
         }
     }
 
@@ -212,7 +211,7 @@ public class PlayerCombat : MonoBehaviour
             return;
         
         // Draws a wireframe sphere in the editor to show the attack range.
-        Gizmos.DrawWireSphere(attackPoint.position, attackRange);
+        Gizmos.DrawWireSphere(attackPoint.position, playerStats.playerAtkRange);
     }
 
     public bool IsDead()

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -2,12 +2,8 @@ using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
 {
-    // Public variables for movement speed, jump force, and max jumps, which is adjustable in Unity.
-    public static float speed = 5f;
-
-    public static float jumpForce = 7f;
-    
-    public static int maxJumps = 2;
+    // Reference Player stats to get changeable attributes
+    private PlayerStats playerStats;
 
     // Reference to the Rigidbody2D component for the physics interactions.
     private Rigidbody2D rb;
@@ -15,14 +11,23 @@ public class PlayerMovement : MonoBehaviour
     // Private variable that tracks how many jumps the player has left.
     private int jumpCount;
 
+    // Boolean value to check if a player has jumped, used to prevent infinite jumps by unequipping and reequipping items.
+    private bool hasJumped;
+
     // Called once when the script starts.
     void Start()
     {
+        // Get the PlayerStats component attached to the same GameObject
+        playerStats = GameObject.Find("StatManager").GetComponent<PlayerStats>();
+
         // Gets and stores the Rigidbody2D component attached to the player.
         rb = GetComponent<Rigidbody2D>();
 
         // Initializes jump count to the maximum allowed jumps.
-        jumpCount = maxJumps;
+        jumpCount = playerStats.playerMaxJumps;
+
+        // Initializes hasJumped to false.
+        hasJumped = false;
     }
 
     // Called once per frame to handle player input.
@@ -32,15 +37,16 @@ public class PlayerMovement : MonoBehaviour
         float moveInput = Input.GetAxis("Horizontal");
 
         // Apply movement by modifying the player's velocity.
-        rb.linearVelocity = new Vector2(moveInput * speed, rb.linearVelocity.y);
+        rb.linearVelocity = new Vector2(moveInput * playerStats.playerSpeed, rb.linearVelocity.y);
 
         // Checks for jump input (W key or Up Arrow key) and ensures the player has jumps remaining.
         if ((Input.GetKeyDown(KeyCode.W) || Input.GetKeyDown(KeyCode.UpArrow)) && jumpCount > 0)
         {
             // Apply an upward force to make the player jump.
-            rb.linearVelocity = new Vector2(rb.linearVelocity.x, jumpForce);
+            rb.linearVelocity = new Vector2(rb.linearVelocity.x, playerStats.playerJumpForce);
 
             jumpCount--; // Reduce jump count when jumping.
+            hasJumped = true;
         }
     }
 
@@ -50,7 +56,14 @@ public class PlayerMovement : MonoBehaviour
         // If the player collides with an object tagged as "Ground", they are considered grounded.
         if (collision.gameObject.CompareTag("Ground") || collision.gameObject.CompareTag("tPlat") || collision.gameObject.CompareTag("platform") || collision.gameObject.CompareTag("Square"))
         {
-            jumpCount = maxJumps;
+            jumpCount = playerStats.playerMaxJumps;
+            hasJumped = false;
         }
+    }
+
+    // Updates jumpCount variable after equipping or unequipping an item that changes the value of playerMaxJumps
+    public void UpdateJumpCount()
+    {
+        if (!hasJumped) { jumpCount = playerStats.playerMaxJumps; }
     }
 }

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using TMPro;
+
+public class PlayerStats : MonoBehaviour
+{
+    public int playerAtkDamage;
+    public float playerAtkRange;
+    public int playerMaxHealth;
+    public float playerSpeed;
+    public float playerJumpForce;
+    public int playerMaxJumps;
+
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        playerAtkDamage = 20;
+        playerAtkRange = 0.5f;
+        playerMaxHealth = 100;
+        playerSpeed = 5f;
+        playerJumpForce = 7f;
+        playerMaxJumps = 2;
+    }
+}

--- a/Assets/Scripts/PlayerStats.cs.meta
+++ b/Assets/Scripts/PlayerStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70e7cb7584e201342a10c32090298fdd


### PR DESCRIPTION
Added StatManager that uses playerStats to initialize and update player attributes attack range and damage, max health and jumps, jump force, and move speed.  Updated PlayerCombat and PlayerMovement to use variables from PlayerStats rather than their own separate fields.  Added method to PlayerMovement to ensure jumps can not be performed infinitely by unequipping and reequipping gear.  Added easy interface to add more items using scriptable objects in their new folder.